### PR TITLE
Restrict branch to run tests on push

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,5 +1,9 @@
 name: Run Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   Test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Restrict the branch to run the tests on push to main, but still run on pull request.