### PR TITLE
Review build tool chain

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,3 +1,4 @@
 distutils-pytest
+git-props
 pytest >=3.0.0
-setuptools_scm
+setuptools

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache__/
 /_meta.py
 /build/
 /dist/
-/test_gha/__init__.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,11 @@ Changelog
 dev (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~
 
++ `#3`_: Review build tool chain
 + `#1`_: Restrict running tests on push to master branch
 
 .. _#1: https://github.com/RKrahl/test-gh-actions/pull/1
+.. _#3: https://github.com/RKrahl/test-gh-actions/pull/3
   
 0.7 (2023-12-17)
 ~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ test:
 sdist:
 	$(PYTHON) setup.py sdist
 
-doc-html: meta
+doc-html: build
 	$(MAKE) -C doc html PYTHONPATH=$(CURDIR)
 
-doc-pdf: meta
+doc-pdf: build
 	$(MAKE) -C doc latexpdf PYTHONPATH=$(CURDIR)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,10 @@ doc-pdf: meta
 
 clean:
 	rm -rf build
-	rm -rf __pycache__ test_gha/__pycache__
+	rm -rf __pycache__
 
 distclean: clean
 	rm -f MANIFEST _meta.py
-	rm -f test_gha/__init__.py
 	rm -rf dist
 	rm -rf tests/.pytest_cache
 	$(MAKE) -C doc distclean

--- a/README.rst
+++ b/README.rst
@@ -18,13 +18,13 @@ Required library packages:
 
 Optional library packages:
 
-+ `setuptools_scm`_
++ `git-props`_
 
-  The version number is managed using this package.  All source
-  distributions add a static text file with the version number and
-  fall back using that if `setuptools_scm` is not available.  So this
-  package is only needed to build out of the plain development source
-  tree as cloned from GitHub.
+  This package is used to extract some metadata such as the version
+  number out of git, the version control system.  All releases embed
+  that metadata in the distribution.  So this package is only needed
+  to build out of the plain development source tree as cloned from
+  GitHub, but not to build a release distribution.
 
 + `pytest`_ >= 3.0
 
@@ -51,7 +51,7 @@ permissions and limitations under the License.
 
 
 .. _setuptools: https://github.com/pypa/setuptools/
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm/
+.. _git-props: https://github.com/RKrahl/git-props
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -16,7 +16,7 @@ copyright = '2023, Rolf Krahl'
 author = 'Rolf Krahl'
 
 # The full version, including alpha/beta/rc tags
-release = _meta.__version__
+release = _meta.version
 # The short X.Y version
 version = ".".join(release.split(".")[0:2])
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -6,8 +6,15 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import _meta
+from pathlib import Path
+import sys
 
+maindir = Path(__file__).resolve().parent.parent.parent
+buildlib = maindir / "build" / "lib"
+sys.path[0] = str(buildlib)
+sys.dont_write_bytecode = True
+
+import test_gha._meta
 
 # -- Project information -----------------------------------------------------
 
@@ -16,7 +23,7 @@ copyright = '2023, Rolf Krahl'
 author = 'Rolf Krahl'
 
 # The full version, including alpha/beta/rc tags
-release = _meta.version
+release = test_gha._meta.version
 # The short X.Y version
 version = ".".join(release.split(".")[0:2])
 
@@ -49,7 +56,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ try:
 except (ImportError, LookupError):
     try:
         import _meta
-        version = _meta.__version__
+        version = _meta.version
     except ImportError:
         log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
@@ -40,7 +40,7 @@ class meta(setuptools.Command):
 __version__ = "%(version)s"
 '''
     meta_template = '''
-__version__ = "%(version)s"
+version = "%(version)s"
 '''
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ try:
 except (ImportError, AttributeError):
     cmdclass = dict()
 try:
-    import setuptools_scm
-    version = setuptools_scm.get_version()
+    import gitprops
+    release = str(gitprops.get_last_release())
+    version = str(gitprops.get_version())
 except (ImportError, LookupError):
     try:
-        import _meta
-        version = _meta.version
+        from _meta import release, version
     except ImportError:
         log.warn("warning: cannot determine version number")
-        version = "UNKNOWN"
+        release = version = "UNKNOWN"
 
 docstring = __doc__
 
@@ -36,6 +36,7 @@ class meta(setuptools.Command):
     description = "generate meta files"
     user_options = []
     meta_template = '''
+release = "%(release)s"
 version = "%(version)s"
 '''
 
@@ -49,6 +50,7 @@ version = "%(version)s"
         version = self.distribution.get_version()
         log.info("version: %s", version)
         values = {
+            'release': release,
             'version': version,
         }
         with Path("_meta.py").open("wt") as f:
@@ -113,11 +115,12 @@ setup(
     ],
     project_urls = dict(
         Source="https://github.com/RKrahl/test-gh-actions",
-        Download="https://github.com/RKrahl/test-gh-actions/releases/latest",
+        Download=("https://github.com/RKrahl/test-gh-actions/releases/%s/"
+                  % release),
     ),
     packages = ["test_gha"],
     package_dir = {"": "src"},
     python_requires = ">=3.6",
-    install_requires = [],
+    install_requires = ["setuptools"],
     cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),
 )

--- a/src/test_gha/__init__.py
+++ b/src/test_gha/__init__.py
@@ -1,0 +1,1 @@
+from ._meta import version as __version__


### PR DESCRIPTION
Review tool chain to build the package:

- Drop `setuptools_scm` in favour of `git-props`,
- Move sources into the new `src` directory,
- Install `_meta.py` as a module into the package,
- Do not auto generate `__init__.py`, add a static `__init__.py` that imports version from `_meta` instead,
- Misc